### PR TITLE
FIX: import dotenv config in db configuration file

### DIFF
--- a/src/config/database.js
+++ b/src/config/database.js
@@ -1,3 +1,5 @@
+require('dotenv/config');
+
 const config = {
   dialect: process.env.DATABASE_DIALECT,
   define: {


### PR DESCRIPTION
Importing dotenv config into src/config/database.js.

This is necessary in order to run sequelize commands to sequelize-cli.